### PR TITLE
adding krmp.cc to colors section

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@
 * [Please JS](http://www.checkman.io/please/)
 * [colourco.de](http://colourco.de)
 * [flatuicolorpicker](http://www.flatuicolorpicker.com/)
+* [krmp.cc](https://github.com/dadleyy/krmp.cc)
 
 ### Font
 


### PR DESCRIPTION
I built a quick golang project that will generate a css sheet with color classes (like those in [materializecss](http://materializecss.com/color.html)) for help while prototyping.