### PR TITLE
add Trimage to list of image compressors

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@
 * [AlloyPhoto](http://alloyteam.github.io/AlloyPhoto/)
 * [Compressor.io](https://compressor.io/)
 * [Shrinkray](https://shrinkray.io)
+* [Trimage](https://trimage.org)
 
 ### JavaScript
 


### PR DESCRIPTION
Trimage is a free desktop application for image compression, combining a number of different CLI tools into a friendly GUI. It's available on Debian, Ubuntu, Arch and other linux systems via the repositories.