### PR TITLE
Adding https link for Beeceptor & change in description

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Tools [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 
->Tools for web
+>An awesome list of hosted tools for web development.
 
 ### Response
 
@@ -120,7 +120,7 @@
 
 * [Hurl.it](https://www.hurl.it/)
 * [requestb.in](http://requestb.in/)
-* [Beeceptor.com](http://beeceptor.com/)
+* [Beeceptor.com](https://beeceptor.com/)
 
 ### API Doc
 


### PR DESCRIPTION
Two changes here:

* Changed to HTTPs list for Beeceptor tool. 
* Added some description for the awesome list.
