### PR TITLE
Changing requestb.in -> requestbin.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@
 ### API Debugging
 
 * [Hurl.it](https://www.hurl.it/)
-* [requestb.in](http://requestb.in/)
+* [RequestBin.com](https://requestbin.com/)
 * [Beeceptor.com](https://beeceptor.com/)
 
 ### API Doc


### PR DESCRIPTION
Requestb.in was shut down, but requestbin.com offers a free, comparable bin service.