### PR TITLE
Removed hurl.it Added another online HTTP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@
 
 ### API Debugging
 
-* [Hurl.it](https://www.hurl.it/)
+* [ExtendsClass.com](https://extendsclass.com/rest-client-online.html)
 * [RequestBin.com](https://requestbin.com/)
 * [Beeceptor.com](https://beeceptor.com/)
 


### PR DESCRIPTION
Hello, I removed hurl.it (dead link). 
I added extendsclass.com (I am the founder) an online http client (like hurl).