### PR TITLE
Add Redirect Checker - HTTP redirect chain analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 * [Webkaka](http://pagespeed.webkaka.com/)
 * [Modern IE Reporting tool](https://www.modern.ie/en-us/report)
 * [GTmetrix](https://gtmetrix.com/)
+* [Redirect Checker](https://redirect-checker.autocompany.workers.dev/) - Analyze HTTP redirect chains and measure performance impact
 
 ### Color
 


### PR DESCRIPTION
## Description

Added [Redirect Checker](https://redirect-checker.autocompany.workers.dev/) to the Pagespeed section.

## What it does

Redirect Checker is a free online tool for analyzing HTTP redirect chains:
- Trace complete redirect chains (301, 302, 307, 308)
- Detect redirect loops
- Measure performance impact at each hop
- Test with different User-Agents (Googlebot, Bingbot, Mobile)

## Why it fits in Pagespeed

Redirect chains directly impact page load performance:
- Each redirect adds DNS + TLS + HTTP latency
- Long chains significantly slow down page loads
- SEO impact from diluted link equity

This tool helps developers identify and debug redirect performance issues.

## Links

- Demo: https://redirect-checker.autocompany.workers.dev/
- Source: https://github.com/brancogao/redirect-checker