### PR TITLE
Add PageGuard to Pagespeed section

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@
 * [Webkaka](http://pagespeed.webkaka.com/)
 * [Modern IE Reporting tool](https://www.modern.ie/en-us/report)
 * [GTmetrix](https://gtmetrix.com/)
+* [PageGuard](https://pageguard.org) - Free all-in-one website health scanner: SEO, performance, accessibility, best practices + AI reports + REST API. No login required.
 
 ### Color
 


### PR DESCRIPTION
Adding [PageGuard](https://pageguard.org) to the Pagespeed section.

PageGuard is a free, all-in-one website health scanner covering:
- SEO analysis
- Performance (Core Web Vitals, Lighthouse scores)
- Accessibility (WCAG checks)
- Best Practices
- AI-generated action plans
- REST API — no login required

A modern companion to PageSpeed Insights and GTmetrix, with AI-powered recommendations.