### PR TITLE
feat: add FastUtil online
  developer tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,5 +190,5 @@
 * [FreeToolBox](https://www.freetoolbox.site/)
 * [Hreflang checker](https://localizely.com/hreflang-checker/)
 * [giga.tools](https://giga.tools/)
-* [FastUtil](https://fastutil.app) - 71+ free browser-based developer tools
+* [FastUtil](https://fastutil.app)
 

--- a/README.md
+++ b/README.md
@@ -190,4 +190,5 @@
 * [FreeToolBox](https://www.freetoolbox.site/)
 * [Hreflang checker](https://localizely.com/hreflang-checker/)
 * [giga.tools](https://giga.tools/)
+* [FastUtil](https://fastutil.app) - 71+ free browser-based developer tools
 


### PR DESCRIPTION
Adds [FastUtil](https://fastutil.app) — 71+ free
   browser-based developer tools. No sign-up, all client-side.