### PR TITLE
Add Mydentify AI Crawler Access Checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,5 +191,5 @@
 * [WebToolkit Pro](https://wtkpro.site/)
 * [FreeToolBox](https://www.freetoolbox.site/)
 * [Hreflang checker](https://localizely.com/hreflang-checker/)
+* [Mydentify AI Crawler Access Checker](https://mydentify.com/tools/ai-crawler-access-checker) - Free, no-signup checker for robots.txt, page-level crawler directives, and ChatGPT and Claude crawler access responses.
 * [giga.tools](https://giga.tools/)
-


### PR DESCRIPTION
## Summary

Adds the free, no-signup Mydentify AI Crawler Access Checker to the hosted web tools collection.

It checks robots.txt, page-level crawler directives, and the HTTP responses returned when a page is requested using documented ChatGPT and Claude crawler user-agent names.

## Disclosure

I maintain Mydentify and am submitting this tool directly. The contribution links to the exact free tool page and makes no ranking or visibility claim.