### PR TITLE
Add Mzu FaviconDL to the Favicon tools list

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@
 * [favicomatic](http://www.favicomatic.com/)
 * [RealFaviconGenerator](https://realfavicongenerator.net/)
 * [favicon.io](https://favicon.io/)
+* [Mzu FaviconDL](https://favicondl.com/)
 
 ### CDN
 
@@ -192,4 +193,3 @@
 * [FreeToolBox](https://www.freetoolbox.site/)
 * [Hreflang checker](https://localizely.com/hreflang-checker/)
 * [giga.tools](https://giga.tools/)
-


### PR DESCRIPTION
你好，我想补充一个与 Favicon 分类匹配的工具：Mzu FaviconDL。

官方入口：https://favicondl.com/
它可从任意网站提取并下载 favicon，支持多尺寸、HTML 片段和开发者 API，打开即可使用且无需注册。

我是该项目维护者，先说明关系方便审核；本次只是按现有列表格式补充一个链接，不涉及付费推荐、互链或徽章。若需要调整名称或分类，欢迎直接修改。