### PR TITLE
Add Responsive Tool to Response category

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@
 * [Screensiz](http://screensiz.es/phone)
 * [Sizzy](http://sizzy.co)
 * [Polypane](http://polypane.rocks)
+* [Responsive Tool](https://responsivetool.com)
 
 ### Placeholder
 


### PR DESCRIPTION
A free, browser-based tool that renders a pasted URL across multiple device viewport sizes (phone, tablet, desktop) at once — the actual pain point being DevTools' one-device-at-a-time toolbar, where switching presets loses your visual context every time. Swap any pane's device instantly or enter a custom pixel width. No signup, no download, nothing stored server-side.


Placed alongside Responsinator, Sizzy, and Polypane since it solves the same class of problem.

Pages on the site:
- [Homepage](https://responsivetool.com/) — the device-grid preview tool itself, plus a short FAQ
- [Device Viewport Sizes](https://responsivetool.com/devices) — reference list of common phone/tablet/laptop/desktop CSS viewport sizes, each linking to a live test
- [CSS Breakpoints Guide](https://responsivetool.com/breakpoints) — common breakpoints mapped to real device sizes, Tailwind/Bootstrap comparisons, copyable media queries, and breakpoint-boundary testing (767/768/769px, etc.)
